### PR TITLE
always exit 0 when stopping service

### DIFF
--- a/bin/wazo-service
+++ b/bin/wazo-service
@@ -205,6 +205,7 @@ stop_services() {
             systemctl stop $service
         fi
     done
+    exit 0
 }
 
 wazo_start_and_open() {


### PR DESCRIPTION
reason: Without explicitly `exit 0`, the code will return the last
returncode from the last service, even if other services have failed.
Which we don't really care when stopping service