### PR TITLE
Fix/default services and miscs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@
 wazo-service aims at managing easily the multiple services needed by Wazo.
 
 ## Developing
-
+wazo-service is a bash wrapper around systemd and monit.
 The docs about Systemd D-bus API is here:
 
 https://www.freedesktop.org/wiki/Software/systemd/dbus/
+
+See also monit manual [1].
+
+[1]: https://mmonit.com/monit/documentation/monit.html

--- a/bin/wazo-service
+++ b/bin/wazo-service
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2018-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 PATH=/bin:/usr/bin:/sbin:/usr/sbin
@@ -11,6 +11,7 @@ default_services="dahdi wazo-plugind wazo-webhookd wazo-sysconfd wazo-confgend w
 all_services="rabbitmq-server consul postgresql nginx $default_services"
 monit_default="/etc/default/monit"
 wazo_disabled_file="/var/lib/wazo/disabled"
+
 
 usage() {
     cat <<-EOF

--- a/bin/wazo-service
+++ b/bin/wazo-service
@@ -6,8 +6,8 @@ PATH=/bin:/usr/bin:/sbin:/usr/sbin
 action=$1
 services_filter=${2:-default}
 include_monit=1
-wazo_services="wazo-dxtora wazo-provd wazo-agid asterisk wazo-amid wazo-call-logd wazo-agentd wazo-dird wazo-phoned wazo-calld wazo-websocketd wazo-chatd"
-default_services="dahdi wazo-plugind wazo-webhookd wazo-sysconfd wazo-confgend wazo-confd wazo-auth $wazo_services"
+wazo_services="wazo-dxtora wazo-provd wazo-agid asterisk wazo-amid wazo-call-logd wazo-agentd wazo-phoned wazo-websocketd"
+default_services="dahdi wazo-plugind wazo-webhookd wazo-sysconfd wazo-confgend wazo-confd wazo-auth wazo-dird wazo-chatd $wazo_services"
 all_services="rabbitmq-server consul postgresql nginx $default_services"
 monit_default="/etc/default/monit"
 wazo_disabled_file="/var/lib/wazo/disabled"
@@ -167,12 +167,12 @@ start_services() {
         exists=$(exists $service)
         enabled=$(is_enabled $service)
         running=$(is_running $service)
-        print_start_service "$optional" "$exists" "$enabled" "$running"
+        start_service "$optional" "$exists" "$enabled" "$running"
     done
     start_monit
 }
 
-print_start_service() {
+start_service() {
     local optional=$1
     local exists=$2
     local enabled=$3


### PR DESCRIPTION
* Updated wazo_services and default_services array to be consistent with underlying systemd config following discussion with @fblackburn1 .
* Updated readme with link to monit manual. Might need to change the link to the proper version used on the servers.